### PR TITLE
:pencil2: 진행도 수정 시 임시로 textContent 사용하던 참조 값 수정

### DIFF
--- a/src/components/CustomCombination/MyCombinationStep.tsx
+++ b/src/components/CustomCombination/MyCombinationStep.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-no-bind */
 import styled from '@emotion/styled';
 import { changeRem } from '@styles/mixin';
 import mediaQuery from '@styles/media-queries';
@@ -5,7 +6,7 @@ import MyCombinationStepBadge from '@components/CustomCombination/MyCombinationS
 
 interface 인터페이스_조합진행도_속성 {
   currentStep: number;
-  onChangeStep: (e: React.MouseEvent<HTMLSpanElement>) => void;
+  onChangeStep: (진행도: number) => void;
 }
 
 const 커스텀진행도_배열: number[] = [1, 2, 3, 4];
@@ -19,7 +20,7 @@ function MyCombinationStep(props: 인터페이스_조합진행도_속성) {
       <CombinationStepList currentStep={현재진행도}>
         {커스텀진행도_배열.map(진행도 => (
           <li key={진행도}>
-            <MyCombinationStepBadge currentStep={현재진행도} onClick={현재진행도_수정}>
+            <MyCombinationStepBadge currentStep={현재진행도} onClick={현재진행도_수정.bind(null, 진행도)}>
               {진행도}
             </MyCombinationStepBadge>
           </li>

--- a/src/pages/CustomCombinationPage.tsx
+++ b/src/pages/CustomCombinationPage.tsx
@@ -9,10 +9,8 @@ import mediaQuery from '@styles/media-queries';
 function CustomCombination() {
   const [현재진행도, 현재진행도_수정] = useState(1);
 
-  const 현재진행도_수정_이벤트 = (e: React.MouseEvent<HTMLSpanElement>) => {
-    const 선택된_진행도 = Number((e.target as HTMLSpanElement).textContent);
-    if (선택된_진행도 < 1 || 선택된_진행도 > 4) return;
-    현재진행도_수정(선택된_진행도);
+  const 현재진행도_수정_이벤트 = (진행도: number) => {
+    현재진행도_수정(진행도);
   };
 
   const 다음_선택지로_이동 = () => {


### PR DESCRIPTION
기존에 나만의 조합 component 내부에서 테스트를 위해 임시로 사용하던 textcontent 를 상태 데이터 인 진행도 로 변경