### PR TITLE
:sparkles: move to top of scroll when routing

### DIFF
--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, ScrollRestoration } from 'react-router-dom';
 import useScrollTop from '@hooks/useScrollTop';
 import Header from '@layouts/Header';
 import Top from '@components/Common/Button/Top';
@@ -10,6 +10,7 @@ function RootLayout() {
 
   return (
     <Layout>
+      <ScrollRestoration />
       <Header />
       <Main>
         <Outlet />


### PR DESCRIPTION
페이지 라우팅 시 이전 스크롤 위치가 아닌 상단으로 스크롤 이동