### PR TITLE
:sparkles: 나만의 조합 등록 기능 임시 완료

### DIFF
--- a/public/data/ingredients.json
+++ b/public/data/ingredients.json
@@ -107,7 +107,7 @@
     "카테고리": "빵",
     "속성유무": false,
     "목록": [
-      { "id": "b1", "이름": "위트", "이미지": "/images/ingredients/bread/Wheat.png", "칼로리": "197" },
+      { "id": "b1", "이름": "위트", "이미지": "/images/ingredients/bread/Wheat.png", "칼로리": "192" },
       {
         "id": "b2",
         "이름": "파마산 오레가노",

--- a/src/components/CustomCombination/CombinationRegistration.tsx
+++ b/src/components/CustomCombination/CombinationRegistration.tsx
@@ -1,12 +1,34 @@
+import { useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { userState } from '@state/index';
 import MyCombinationCard from '@components/CustomCombination/MyCombinationCard';
 import Button from '@components/UI/Button';
+import postCustom from '@utils/customCombination/postCustom';
+
 import styled from '@emotion/styled';
 import mediaQuery from '@styles/media-queries';
+import { 인터페이스_꿀조합 } from '@typings/ISandwich';
 
-function CombinationRegistration() {
+type TProps = {
+  customCombination: 인터페이스_꿀조합;
+  onChange: (선택한재료: 인터페이스_꿀조합) => void;
+};
+
+function CombinationRegistration(props: TProps) {
+  const [inputValue, setInputValue] = useState('');
+  const { customCombination, onChange } = props;
+  const user = useRecoilValue(userState);
+  const userInfo = { id: user?.uid, name: user?.displayName };
+
+  const 클릭핸드러_나만의_조합_등록하기 = (e: React.FormEvent) => {
+    e.preventDefault();
+    postCustom({ customCombination, onChange, inputValue, userInfo });
+    setInputValue('');
+  };
+
   return (
-    <CustomForm>
-      <MyCombinationCard />
+    <CustomForm onSubmit={클릭핸드러_나만의_조합_등록하기}>
+      <MyCombinationCard userName={user?.displayName} inputValue={inputValue} setInputValue={setInputValue} />
       <CreateCombinationButton designType="primaryGreen" width="100%" padding="15px" fontSize="16px" fontWeight="700">
         나만의 조합 만들기
       </CreateCombinationButton>

--- a/src/components/CustomCombination/MyCombinationCard.tsx
+++ b/src/components/CustomCombination/MyCombinationCard.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import Button from '@components/UI/Button';
 
 import SandwichBL from '@assets/images/sandwich_B.L.png';
@@ -8,7 +9,17 @@ import styled from '@emotion/styled';
 import mediaQuery from '@styles/media-queries';
 import { changeRem } from '@styles/mixin';
 
-function MyCombinationCard() {
+type TProps = {
+  inputValue: string;
+  setInputValue: React.Dispatch<React.SetStateAction<string>>;
+  userName: string | undefined | null;
+};
+
+function MyCombinationCard(props: TProps) {
+  const { setInputValue, userName, inputValue } = props;
+
+  const 체인지핸들러_꿀조합제목_입력하기 = (e: React.ChangeEvent<HTMLInputElement>) => setInputValue(e.target.value);
+
   return (
     <Container>
       <Danzzi src={danzziTrust} alt="단찌 믿음 아이콘" />
@@ -17,14 +28,19 @@ function MyCombinationCard() {
           <img src={deleteBtn} alt="조합 삭제 버튼" />
         </DeleteBtn>
         <Text>
-          <UserName className="title">단찌</UserName>
+          <UserName className="title">{userName}</UserName>
           <span>만의 조합 완성</span>
         </Text>
         <SubTitle>이 조합으로 세계정복!!</SubTitle>
         <CardContentWrap>
           <Img src={SandwichBL} alt="샌드위치 이미지" />
           <CardInputButtonWrap>
-            <Input type="text" placeholder="왓썹의 이름은..?" />
+            <Input
+              onChange={체인지핸들러_꿀조합제목_입력하기}
+              value={inputValue}
+              type="text"
+              placeholder="왓썹의 이름은..?"
+            />
             <CreateCombinationButton
               designType="primaryGreen"
               width="100%"
@@ -60,6 +76,15 @@ const Card = styled.div`
   }
 `;
 
+const Text = styled.div`
+  text-align: center;
+  & span {
+    vertical-align: text-bottom;
+    font-weight: 700;
+    font-size: 20px;
+  }
+`;
+
 const UserName = styled.h2`
   display: inline;
   color: #fab608;
@@ -67,15 +92,10 @@ const UserName = styled.h2`
   font-size: 24px;
   padding-right: 3px;
 `;
-const Text = styled.div`
-  text-align: center;
-  & span {
-    font-weight: 700;
-    font-size: 20px;
-  }
-`;
+
 const SubTitle = styled.p`
   font-weight: 400;
+
   text-align: center;
   color: #979797;
   margin: 0;

--- a/src/components/CustomCombination/SelectCombination.tsx
+++ b/src/components/CustomCombination/SelectCombination.tsx
@@ -1,8 +1,7 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
-
 import Ingredient from '@components/CustomCombination/Ingredient';
-
+import { INGREDIENT_PATH, RECIPE_PATH } from '@constants/constants';
 import styled from '@emotion/styled';
 import { changeRem } from '@styles/mixin';
 
@@ -12,9 +11,6 @@ import {
   인터페이스_레시피,
   인터페이스_선택된_재료,
 } from '@typings/ISandwich';
-
-const INGREDIENT_PATH = '/data/ingredients.json';
-const RECIPE_PATH = '/data/recipe.json';
 
 type TProps = {
   customCombination: 인터페이스_꿀조합;

--- a/src/components/CustomCombination/SelectComponent.tsx
+++ b/src/components/CustomCombination/SelectComponent.tsx
@@ -7,14 +7,14 @@ import { changeRem } from '@styles/mixin';
 
 import { 인터페이스_꿀조합 } from '@typings/ISandwich';
 
-type 타입_재료선택_속성 = {
+type TProps = {
   customCombination: 인터페이스_꿀조합;
   currentStep: number;
   onChange: (선택한재료: 인터페이스_꿀조합) => void;
   onNextStep: () => void;
 };
 
-function SelectComponent(props: 타입_재료선택_속성) {
+function SelectComponent(props: TProps) {
   const {
     currentStep: 현재진행도,
     onNextStep: 다음_선택지로_이동하기,
@@ -34,7 +34,7 @@ function SelectComponent(props: 타입_재료선택_속성) {
           <NextStepButton currentStep={현재진행도} onNextStep={다음_선택지로_이동하기} />
         </>
       ) : (
-        <CombinationRegistration />
+        <CombinationRegistration customCombination={나만의_조합} onChange={체인지핸들러_나만의_조합_수정} />
       )}
     </SelectWrap>
   );

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -27,7 +27,7 @@ export const 메뉴정보: 타입_메뉴[] = [
     이동링크: '/custom-combination',
     아이콘: customImg,
     아이콘설명: '커스텀 아이콘',
-    로그인상관여부: false,
+    로그인상관여부: true,
   },
   {
     메뉴명: '마이페이지',
@@ -43,3 +43,6 @@ export const 꿀조합_픽_초기_필터: 인터페이스_꿀조합선택페이�
   재료: [],
   추가사항: [],
 };
+
+export const INGREDIENT_PATH = '/data/ingredients.json';
+export const RECIPE_PATH = '/data/recipe.json';

--- a/src/typings/ISandwich.ts
+++ b/src/typings/ISandwich.ts
@@ -43,6 +43,8 @@ export interface 인터페이스_재료정보 {
   칼로리: string;
 }
 
+export type 인터페이스_메인재료 = 인터페이스_꿀조합_재료;
+
 export interface 인터페이스_재료 {
   id?: string;
   이름: string;

--- a/src/utils/customCombination/combinationVerification.ts
+++ b/src/utils/customCombination/combinationVerification.ts
@@ -7,9 +7,8 @@ const firstStepValidation = (나만의_조합: 인터페이스_꿀조합) => {
 
 const secondStepValidation = (나만의_조합: 인터페이스_꿀조합) => {
   const isSelectedBread = !!나만의_조합.선택재료.find(재료 => 재료.카테고리 === '빵');
-  // const isToasted = !!나만의_조합.토스팅;
-  // return isSelectedBread && isToasted;
-  return isSelectedBread;
+  const isToasted = !!나만의_조합.토스팅;
+  return isSelectedBread && isToasted;
 };
 
 const combinationVerification = (진행도: number, 나만의_조합: 인터페이스_꿀조합) => {

--- a/src/utils/customCombination/postCustom.ts
+++ b/src/utils/customCombination/postCustom.ts
@@ -1,0 +1,69 @@
+import axios from 'axios';
+
+import { RECIPE_PATH, INGREDIENT_PATH } from '@constants/constants';
+
+import { 인터페이스_꿀조합, 인터페이스_레시피, 인터페이스_메인재료 } from '@typings/ISandwich';
+
+type TProps = {
+  customCombination: 인터페이스_꿀조합;
+  onChange?: (선택한재료: 인터페이스_꿀조합) => void;
+  inputValue: string;
+  userInfo: { id: string | undefined; name: string | null | undefined };
+};
+
+const 뱃지리스트_추가하기 = async (
+  조합: 인터페이스_꿀조합,
+  나만의_조합: 인터페이스_꿀조합,
+  recipeData: 인터페이스_레시피[]
+) => {
+  const ingredientRes = await axios.get(INGREDIENT_PATH);
+  const 전체_메인재료_목록: 인터페이스_메인재료[] = ingredientRes.data[0].목록;
+
+  const 메인재료 = recipeData.find(레시피 => 레시피.이름 === 조합.베이스샌드위치)?.재료목록 as string[];
+  const 재료_뱃지 = 메인재료.map(메인재료 => 전체_메인재료_목록.find(재료 => 재료.이름 === 메인재료)?.속성);
+
+  조합.뱃지리스트.재료 = [...new Set(재료_뱃지)] as string[];
+
+  나만의_조합.선택재료.map(재료 => {
+    if (재료.카테고리 === '추가재료' && !조합.뱃지리스트.추가사항.includes(재료.속성 as string))
+      조합.뱃지리스트.추가사항.push(재료.속성 as string);
+    else if (재료.카테고리 === '소스' && !조합.뱃지리스트.맛.includes(재료.속성 as string))
+      조합.뱃지리스트.맛.push(재료.속성 as string);
+    return undefined;
+  });
+};
+
+const 조합_정리하기 = async (props: TProps) => {
+  const { customCombination: 나만의_조합, inputValue: 꿀조합_제목, userInfo } = props;
+
+  const today = new Date();
+  const 조합 = { ...나만의_조합 };
+  const recipeRes = await axios.get(RECIPE_PATH);
+  const recipeData: 인터페이스_레시피[] = recipeRes.data;
+  let 총_칼로리 = Number(recipeData.find(레시피 => 레시피.이름 === 조합.베이스샌드위치)?.재료칼로리 as string);
+  총_칼로리 += 조합.선택재료
+    .map(재료 => (재료.이름 === '더블업' ? 총_칼로리 : Number(재료.칼로리)))
+    .reduce((pre, cur) => pre + cur, 0);
+
+  조합.꿀조합제목 = 꿀조합_제목;
+  조합.작성자 = userInfo.name as string;
+  조합.작성자id = userInfo.id as string;
+  조합.작성일 = `${today.getFullYear()}-${today.getMonth() + 1}-${today.getDate()}`;
+  조합.칼로리 = 총_칼로리.toFixed(1).toString();
+
+  뱃지리스트_추가하기(조합, 나만의_조합, recipeData);
+
+  return 조합;
+};
+
+const postCustom = async (props: TProps) => {
+  const { customCombination, onChange: 체인지핸들러_나만의_조합_수정, inputValue, userInfo } = props;
+
+  if (!inputValue.trim()) return alert('제목을 입력해주세요');
+
+  const 조합_정보 = await 조합_정리하기({ customCombination, inputValue, userInfo });
+
+  console.log(조합_정보);
+};
+
+export default postCustom;


### PR DESCRIPTION
-  커스텀 페이지 (조합 페이지)에 로그인 후에 접근 가능하게 변경
-  등록 페이지에서 유저 정보 불러와서 조합 카드에 유저 아이디를 렌더
-  나만의 조합 버튼 클릭 시 꿀 조합 데이터 양식에 맞게 유저 정보 및 칼로리 등을 가공 후 서버에 post 하는 기능 추가 (임시)