### PR TITLE
:sparkles: delete bestCombination transaction control

### DIFF
--- a/src/hooks/useDeleteBestCombination.tsx
+++ b/src/hooks/useDeleteBestCombination.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
-import { dbDelete } from '@api/index';
 import { userState } from '@state/index';
+import { collection, doc, getDocs, query, runTransaction, where } from 'firebase/firestore';
+import { db } from '../firebase.config';
 
 const useDeleteBestCombination = (꿀조합id: string) => {
   const [isShowModal, setIsShowModal] = useState(false);
@@ -13,13 +14,33 @@ const useDeleteBestCombination = (꿀조합id: string) => {
     setIsShowModal(prev => !prev);
   };
 
-  const 꿀조합_삭제하기 = () => {
+  const 꿀조합_삭제하기 = async () => {
     try {
-      dbDelete('꿀조합', 꿀조합id).then(() => {
+      await runTransaction(db, async transaction => {
+        const 삭제할_댓글_꿀조합_쿼리스냅샷 = await getDocs(
+          query(collection(db, '댓글_꿀조합'), where('bestCombinationId', '==', 꿀조합id))
+        );
+        const 업데이트할_좋아요_쿼리스냅샷 = await getDocs(
+          query(collection(db, '좋아요'), where('좋아요_리스트', 'array-contains', 꿀조합id))
+        );
+
+        삭제할_댓글_꿀조합_쿼리스냅샷.forEach(async 문서 => {
+          await transaction.delete(doc(collection(db, '댓글_꿀조합'), 문서.id));
+        });
+
+        업데이트할_좋아요_쿼리스냅샷.forEach(async 문서 => {
+          const { 좋아요_리스트 } = 문서.data();
+          await transaction.update(doc(collection(db, '좋아요'), 유저!.uid), {
+            좋아요_리스트: 좋아요_리스트.filter((id: string) => id !== 꿀조합id),
+          });
+        });
+        await transaction.delete(doc(collection(db, '꿀조합'), 꿀조합id));
+      }).then(() => {
+        console.log('댓글 삭제 Transaction 커밋 성공!');
         navigate(-1);
       });
-    } catch {
-      console.error('꿀조합 삭제하기 실패');
+    } catch (error) {
+      console.error('꿀조합 삭제 Transaction 커밋 실패', error);
     }
   };
 


### PR DESCRIPTION
## 꿀조합 삭제 트랜젝션 처리
- 꿀조합 삭제 시 꿀조합의 댓글도 삭제한다.
- 꿀조합 삭제 시 유저 좋아요 리스트에서 제외한다.
- 꿀조합 게시물을 삭제한다.
- 위 3가지 사항 중 한가지라도 실패하면 꿀조합이 삭제 되지 않는다.