### PR TITLE
:lipstick: add NotFound_Image min-height for layout shift prevention

### DIFF
--- a/src/components/BestCombinationList/NotFoundBestCombinationList.tsx
+++ b/src/components/BestCombinationList/NotFoundBestCombinationList.tsx
@@ -34,15 +34,20 @@ function NotFoundBestCombinationList() {
 export default NotFoundBestCombinationList;
 
 const ImgWrap = styled.div`
-  max-width: 250px;
+  max-width: ${changeRem(250)};
 
   & img {
     width: 100%;
     height: 100%;
+    min-height: ${changeRem(251)};
   }
 
   ${mediaQuery} {
-    min-width: 350px;
+    min-width: ${changeRem(350)};
+
+    & img {
+      min-height: ${changeRem(351)};
+    }
   }
 `;
 


### PR DESCRIPTION
- 꿀조합 리스트를 못 찾을 시 보여지는 이미지 min-height 속성 추가 (레이아웃 쉬프트 방지)