### PR TITLE
:recycle: 커스텀 페이지에서 샌드위치 제목 input으로 인한 리랜더 개선

### DIFF
--- a/src/components/CustomCombination/CombinationRegistration.tsx
+++ b/src/components/CustomCombination/CombinationRegistration.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef } from 'react';
 import { useRecoilValue } from 'recoil';
 import { useNavigate } from 'react-router-dom';
 import { userState } from '@state/index';
@@ -16,18 +16,21 @@ type TProps = {
 };
 
 function CombinationRegistration(props: TProps) {
-  const [inputValue, setInputValue] = useState('');
   const { customCombination, changeModalType } = props;
   const user = useRecoilValue(userState);
   const userInfo = { id: user?.uid, name: user?.displayName };
   const navigate = useNavigate();
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const 클릭핸드러_나만의_조합_등록하기 = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!inputValue.trim()) return changeModalType('TitleCheck');
 
-    const 조합_등록 = await postCustom({ customCombination, inputValue, userInfo });
-    setInputValue('');
+    if (!inputRef.current?.value.trim()) {
+      (inputRef.current as HTMLInputElement).value = '';
+      return changeModalType('TitleCheck');
+    }
+
+    const 조합_등록 = await postCustom({ customCombination, value: inputRef.current.value, userInfo });
     navigate(`/best-combination/${조합_등록?.id}`);
   };
 
@@ -35,8 +38,7 @@ function CombinationRegistration(props: TProps) {
     <CustomForm onSubmit={클릭핸드러_나만의_조합_등록하기}>
       <MyCombinationCard
         userName={user?.displayName}
-        inputValue={inputValue}
-        setInputValue={setInputValue}
+        ref={inputRef}
         customCombination={customCombination}
         changeModalType={changeModalType}
       />

--- a/src/components/CustomCombination/MyCombinationCard.tsx
+++ b/src/components/CustomCombination/MyCombinationCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, forwardRef, ForwardedRef } from 'react';
 import Button from '@components/Common/UI/Button';
 import setFirebaseImgURL from '@services/Firebase/setFirebaseImgURL';
 import recipe from '@data/recipe';
@@ -13,18 +13,14 @@ import { changeRem } from '@styles/mixin';
 import { 인터페이스_생성단계_꿀조합 } from '@typings/ISandwich';
 
 type TProps = {
-  inputValue: string;
-  setInputValue: React.Dispatch<React.SetStateAction<string>>;
   userName: string | undefined | null;
   customCombination: 인터페이스_생성단계_꿀조합;
   changeModalType: (type: string) => void;
 };
 
-function MyCombinationCard(props: TProps) {
-  const { setInputValue, userName, inputValue, customCombination: 나만의_조합, changeModalType } = props;
+function MyCombinationCard(props: TProps, inputRef: ForwardedRef<HTMLInputElement>) {
+  const { userName, customCombination: 나만의_조합, changeModalType } = props;
   const [sandwichImg, setSandwichImg] = useState('');
-
-  const 체인지핸들러_꿀조합제목_입력하기 = (e: React.ChangeEvent<HTMLInputElement>) => setInputValue(e.target.value);
 
   useEffect(() => {
     setSandwichImg(
@@ -50,11 +46,10 @@ function MyCombinationCard(props: TProps) {
           <Img src={sandwichImg} alt="샌드위치 이미지" />
           <CardInputButtonWrap>
             <Input
-              onChange={체인지핸들러_꿀조합제목_입력하기}
+              ref={inputRef}
               pattern=".{2,20}"
               required
               title="2 ~ 20 글자 이내로 제목을 정해주세요"
-              value={inputValue}
               type="text"
               placeholder="왓썹의 이름은..?"
             />
@@ -73,7 +68,7 @@ function MyCombinationCard(props: TProps) {
   );
 }
 
-export default MyCombinationCard;
+export default forwardRef(MyCombinationCard);
 
 const Container = styled.div`
   position: relative;

--- a/src/services/customCombination/postCustom.ts
+++ b/src/services/customCombination/postCustom.ts
@@ -8,7 +8,7 @@ import { 인터페이스_생성단계_꿀조합, 인터페이스_메인재료 } 
 
 type TProps = {
   customCombination: 인터페이스_생성단계_꿀조합;
-  inputValue: string;
+  value: string;
   userInfo: { id: string | undefined; name: string | null | undefined };
 };
 
@@ -30,7 +30,7 @@ const 뱃지리스트_추가하기 = (조합: 인터페이스_생성단계_꿀�
 };
 
 const 조합_정리하기 = (props: TProps) => {
-  const { customCombination: 나만의_조합, inputValue: 꿀조합_제목, userInfo } = props;
+  const { customCombination: 나만의_조합, value: 꿀조합_제목, userInfo } = props;
 
   const 조합 = { ...나만의_조합 };
 
@@ -57,9 +57,9 @@ const 조합_정리하기 = (props: TProps) => {
 };
 
 const postCustom = async (props: TProps) => {
-  const { customCombination, inputValue, userInfo } = props;
+  const { customCombination, value, userInfo } = props;
 
-  const 조합_정보 = 조합_정리하기({ customCombination, inputValue, userInfo });
+  const 조합_정보 = 조합_정리하기({ customCombination, value, userInfo });
   const 조합_등록 = await dbPush('꿀조합', 조합_정보);
 
   return 조합_등록;


### PR DESCRIPTION
- 커스텀 페이지에서 샌드위치 제목 input으로 인한 리랜더 개선 
기존 input에 useState를 사용하던 방식에서 ref를 사용하여 제목 작성 시 계속 리랜더 되는 현상을 개선